### PR TITLE
[FIX] disables drag and dropping inline icons.

### DIFF
--- a/Resources/Public/Javascript/Editor.js
+++ b/Resources/Public/Javascript/Editor.js
@@ -67,6 +67,11 @@ var Editor = (function($){
         $inlineActions.each(function(index) {
             var that = $(this);
 
+            // disable dragging icons by mistake
+            that.find('img').on('dragstart', function() {
+                return false;
+            });
+
             // Add new action
             that.find('.icon-actions-edit-add').on('click', function() {
                 F.confirm(F.translate('notifications.add-content-element'), {

--- a/Resources/Public/Javascript/Editor.js
+++ b/Resources/Public/Javascript/Editor.js
@@ -67,7 +67,7 @@ var Editor = (function($){
         $inlineActions.each(function(index) {
             var that = $(this);
 
-            // disable dragging icons by mistake
+            // Disable dragging icons by mistake
             that.find('img').on('dragstart', function() {
                 return false;
             });


### PR DESCRIPTION
Simply disables dragstart. Fix for: #111 